### PR TITLE
Add migration to Pump IDL

### DIFF
--- a/pumpfun/pump.json
+++ b/pumpfun/pump.json
@@ -105,6 +105,37 @@
       ]
     },
     {
+      "name": "migrate",
+      "docs": ["Migrates liquidity to pump_amm if the bonding curve is complete."],
+      "accounts": [
+        { "name": "global", "isMut": false, "isSigner": false },
+        { "name": "withdrawAuthority", "isMut": true, "isSigner": false },
+        { "name": "mint", "isMut": false, "isSigner": false },
+        { "name": "bondingCurve", "isMut": true, "isSigner": false },
+        { "name": "associatedBondingCurve", "isMut": true, "isSigner": false },
+        { "name": "user", "isMut": true, "isSigner": true },
+        { "name": "systemProgram", "isMut": false, "isSigner": false },
+        { "name": "tokenProgram", "isMut": false, "isSigner": false },
+        { "name": "pumpAmm", "isMut": false, "isSigner": false },
+        { "name": "pool", "isMut": true, "isSigner": false },
+        { "name": "poolAuthority", "isMut": true, "isSigner": false },
+        { "name": "poolAuthorityMintAccount", "isMut": true, "isSigner": false },
+        { "name": "poolAuthorityWsolAccount", "isMut": true, "isSigner": false },
+        { "name": "ammGlobalConfig", "isMut": false, "isSigner": false },
+        { "name": "wsolMint", "isMut": false, "isSigner": false },
+        { "name": "lpMint", "isMut": true, "isSigner": false },
+        { "name": "userPoolTokenAccount", "isMut": true, "isSigner": false },
+        { "name": "poolBaseTokenAccount", "isMut": true, "isSigner": false },
+        { "name": "poolQuoteTokenAccount", "isMut": true, "isSigner": false },
+        { "name": "token2022Program", "isMut": false, "isSigner": false },
+        { "name": "associatedTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "pumpAmmEventAuthority", "isMut": false, "isSigner": false },
+        { "name": "eventAuthority", "isMut": false, "isSigner": false },
+        { "name": "program", "isMut": false, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
       "name": "withdraw",
       "docs": [
         "Allows the admin to withdraw liquidity for a migration once the bonding curve completes"


### PR DESCRIPTION
Hey @astudnev. When running a Kafka stream with Bitquery i'm not able to detect migrations using the 'migrate' program method for Pump, even though 'buy' and 'sell' work just fine. I assume you guys are using this IDL for the `Method` field in `Program` struct in the ParsedIDLIntstruction. 

```
type Program struct {
	state         protoimpl.MessageState
	sizeCache     protoimpl.SizeCache
	unknownFields protoimpl.UnknownFields

	Address      []byte            `protobuf:"bytes,1,opt,name=Address,proto3" json:"Address,omitempty"`
	Parsed       bool              `protobuf:"varint,2,opt,name=Parsed,proto3" json:"Parsed,omitempty"`
	Json         string            `protobuf:"bytes,3,opt,name=Json,proto3" json:"Json,omitempty"`
	Signature    []byte            `protobuf:"bytes,4,opt,name=Signature,proto3" json:"Signature,omitempty"`
	Name         string            `protobuf:"bytes,5,opt,name=Name,proto3" json:"Name,omitempty"`
	Method       string            `protobuf:"bytes,6,opt,name=Method,proto3" json:"Method,omitempty"`
	Arguments    []*ParsedArgument `protobuf:"bytes,7,rep,name=Arguments,proto3" json:"Arguments,omitempty"`
	AccountNames []string          `protobuf:"bytes,8,rep,name=AccountNames,proto3" json:"AccountNames,omitempty"`
}
```

If this is not the reason then please explain why before closing the PR.